### PR TITLE
readme: fix composer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ tool will create a zip file.
 Prefer to use the tool locally? You can install `json2dto` via composer and generate files directly from json files.
 
 ```bash
-composer global install atymic/json2dto # Install Globally
+composer global require atymic/json2dto # Install Globally
 
-composer install atymic/json2dto --dev # Install locally in a project
+composer require atymic/json2dto --dev # Install locally in a project
 ```
 
 ### Usage


### PR DESCRIPTION
You can't use "install" to install individual packages, it's "require"