### PR TITLE
console: don't require value for pure boolean options

### DIFF
--- a/json2dto/src/Commands/GenerateDto.php
+++ b/json2dto/src/Commands/GenerateDto.php
@@ -24,10 +24,10 @@ class GenerateDto extends Command
             ->addArgument('namespace', InputArgument::REQUIRED, 'Namespace to generate the class(es) in')
             ->addArgument('json', InputArgument::OPTIONAL, 'File containing the json string')
             ->addOption('classname', 'name', InputOption::VALUE_OPTIONAL, 'Class name of the new DTO', 'NewDto')
-            ->addOption('nested', null, InputOption::VALUE_OPTIONAL, 'Generate nested DTOs', false)
-            ->addOption('typed', null, InputOption::VALUE_OPTIONAL, 'Generate PHP >= 7.4 strict typing', false)
-            ->addOption('flexible', null, InputOption::VALUE_OPTIONAL, 'Generate a flexible DTO', false)
-            ->addOption('dry', null, InputOption::VALUE_OPTIONAL, 'Dry run, print generated files', false);
+            ->addOption('nested', null, InputOption::VALUE_NONE, 'Generate nested DTOs')
+            ->addOption('typed', null, InputOption::VALUE_NONE, 'Generate PHP >= 7.4 strict typing')
+            ->addOption('flexible', null, InputOption::VALUE_NONE, 'Generate a flexible DTO')
+            ->addOption('dry', null, InputOption::VALUE_NONE, 'Dry run, print generated files');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
Otherwise this leads to strange bugs like this:
```
$ vendor/bin/json2dto generate --nested --flexible App\\Dto test.json
Failed to parse JSON file
```
Because the command things the namespace is the value for `--flexible` 🤷‍♀️

With the PR, it works:
```
$ vendor/bin/json2dto generate --nested --flexible App\\Dto test.json
Created App/Dto/NestedStructure.php
Created App/Dto/NewDto.php
```