### PR TITLE
Bump versions of illuminate and symfony dependencies

### DIFF
--- a/json2dto/composer.json
+++ b/json2dto/composer.json
@@ -18,10 +18,10 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
-        "illuminate/support": "~5.5 || ~6.0",
+        "illuminate/support": "~5.5 || ~6.0 || ~7.0 || ~8.0",
         "nette/php-generator": "^3.3",
         "spatie/data-transfer-object": "^1.13  || ^2.0",
-        "symfony/console": "^4.2"
+        "symfony/console": "^4.2 || ^5.0"
 
     },
     "require-dev": {


### PR DESCRIPTION
Addresses #33 

I have opened up the version requirements to allow for the package to work with a Laravel 8 installation. I have checked to make sure the package and the app will work with new and old dependencies It looks like none of the changes effect this package and app.